### PR TITLE
Update yunohost.conf

### DIFF
--- a/data/templates/fail2ban/yunohost.conf
+++ b/data/templates/fail2ban/yunohost.conf
@@ -14,7 +14,7 @@
 #          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
 # Values:  TEXT
 #
-failregex = access.lua:[1-9]+: authenticate\(\): Connection failed for: .*, client: <HOST>
+failregex = helpers.lua:[1-9]+: authenticate\(\): Connection failed for: .*, client: <HOST>
             ^<HOST> -.*\"POST /yunohost/api/login HTTP/1.1\" 401 22
 
 # Option:  ignoreregex


### PR DESCRIPTION
The failed auth log events (as shown in my nginx error.log) are "helpers.lua", not "access.lua".